### PR TITLE
[WIP] add o2r-loader to platform

### DIFF
--- a/test/docker-compose-host-nginx.yml
+++ b/test/docker-compose-host-nginx.yml
@@ -41,6 +41,23 @@ services:
     networks:
       - "o2rnet"
 
+  loader:
+    image: o2rproject/o2r-loader:latest
+    restart: unless-stopped
+    volumes:
+      - o2r_test_storage:/tmp/o2r
+      - /var/run/docker.sock:/var/run/docker.sock
+    external_links:
+      - "test_mongodb_1:mongodb"
+    environment:
+      - "LOADER_MONGODB=mongodb://mongodb"
+      - LOADER_PORT=8088
+      - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+    ports:
+      - "8088:8088"
+    networks:
+      - "o2rnet"
+
   contentbutler:
     image: o2rproject/o2r-contentbutler:latest
     restart: unless-stopped

--- a/test/docker-compose-local-platformcontainer.yml
+++ b/test/docker-compose-local-platformcontainer.yml
@@ -41,6 +41,23 @@ services:
     networks:
       - "o2rnet"
 
+  loader:
+    image: loader
+    restart: unless-stopped
+    volumes:
+      - o2r_test_storage:/tmp/o2r
+      - /var/run/docker.sock:/var/run/docker.sock
+    external_links:
+      - "test_mongodb_1:mongodb"
+    environment:
+      - "LOADER_MONGODB=mongodb://mongodb"
+      - LOADER_PORT=8088
+      - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+    ports:
+      - "8088:8088"
+    networks:
+      - "o2rnet"
+
   contentbutler:
     image: contentbutler
     restart: unless-stopped

--- a/test/docker-compose-local.yml
+++ b/test/docker-compose-local.yml
@@ -41,6 +41,23 @@ services:
     networks:
       - "o2rnet"
 
+  loader:
+    image: loader
+    restart: unless-stopped
+    volumes:
+      - o2r_test_storage:/tmp/o2r
+      - /var/run/docker.sock:/var/run/docker.sock
+    external_links:
+      - "test_mongodb_1:mongodb"
+    environment:
+      - "LOADER_MONGODB=mongodb://mongodb"
+      - LOADER_PORT=8088
+      - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+    ports:
+      - "8088:8088"
+    networks:
+      - "o2rnet"
+
   contentbutler:
     image: contentbutler
     restart: unless-stopped

--- a/test/docker-compose-remote-toolbox.yml
+++ b/test/docker-compose-remote-toolbox.yml
@@ -43,6 +43,23 @@ services:
     networks:
       - "o2rnet"
 
+  loader:
+    image: o2rproject/o2r-loader:latest
+    restart: unless-stopped
+    volumes:
+      - o2r_test_storage:/tmp/o2r
+      - /var/run/docker.sock:/var/run/docker.sock
+    external_links:
+      - "test_mongodb_1:mongodb"
+    environment:
+      - "LOADER_MONGODB=mongodb://mongodb"
+      - LOADER_PORT=8088
+      - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+    ports:
+      - "8088:8088"
+    networks:
+      - "o2rnet"
+
   contentbutler:
     image: o2rproject/o2r-contentbutler:latest
     restart: unless-stopped

--- a/test/docker-compose-remote.yml
+++ b/test/docker-compose-remote.yml
@@ -43,6 +43,23 @@ services:
     networks:
       - "o2rnet"
 
+  loader:
+    image: o2rproject/o2r-loader:latest
+    restart: unless-stopped
+    volumes:
+      - o2r_test_storage:/tmp/o2r
+      - /var/run/docker.sock:/var/run/docker.sock
+    external_links:
+      - "test_mongodb_1:mongodb"
+    environment:
+      - "LOADER_MONGODB=mongodb://mongodb"
+      - LOADER_PORT=8088
+      - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+    ports:
+      - "8088:8088"
+    networks:
+      - "o2rnet"
+
   contentbutler:
     image: o2rproject/o2r-contentbutler:latest
     restart: unless-stopped

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -41,6 +41,23 @@ services:
     networks:
       - "o2rnet"
 
+  loader:
+    image: o2rproject/o2r-loader:latest
+    restart: unless-stopped
+    volumes:
+      - o2r_test_storage:/tmp/o2r
+      - /var/run/docker.sock:/var/run/docker.sock
+    external_links:
+      - "test_mongodb_1:mongodb"
+    environment:
+      - "LOADER_MONGODB=mongodb://mongodb"
+      - LOADER_PORT=8088
+      - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+    ports:
+      - "8088:8088"
+    networks:
+      - "o2rnet"
+
   contentbutler:
     image: o2rproject/o2r-contentbutler:latest
     restart: unless-stopped

--- a/test/nginx-host-nginx.conf
+++ b/test/nginx-host-nginx.conf
@@ -84,5 +84,11 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_pass http://localhost:8087;
     }
+
+    location /api/v2/compendium {
+      proxy_pass http://172.17.0.1:8088;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+    }
   }
 }

--- a/test/nginx-platformcontainer.conf
+++ b/test/nginx-platformcontainer.conf
@@ -83,5 +83,11 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_pass http://172.17.0.1:8087;
     }
+
+    location /api/v2/compendium {
+      proxy_pass http://172.17.0.1:8088;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+    }
   }
 }

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -84,5 +84,11 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_pass http://172.17.0.1:8087;
     }
+
+    location /api/v2/compendium {
+      proxy_pass http://172.17.0.1:8088;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+    }
   }
 }


### PR DESCRIPTION
Adds the o2r-loader to all docker-compose and nginx configurations. I took most things from the o2r-muncher and changed them.

- do I need the second volume (`- /var/run/docker.sock:/var/run/docker.sock`) for the loader?
- not sure what this does / if it is needed in the nginx.conf: 

``` 
proxy_redirect off;
proxy_set_header Host $host;
```
