### PR TITLE
Update for latest o2r-muncher, o2r-loader and o2r-transporter

### DIFF
--- a/client/app/creationProcess/creationObject.factory.js
+++ b/client/app/creationProcess/creationObject.factory.js
@@ -59,6 +59,9 @@
         }
 
         function getRequired(){
+            let viewfiles_fix = erc.metadata.o2r.viewfiles;
+            viewfiles_fix.push(erc.metadata.o2r.paperSource);
+
             var required = {
                 title: erc.metadata.o2r.title,
                 description: erc.metadata.o2r.description,
@@ -66,7 +69,7 @@
                 softwarePaperCitation: erc.metadata.o2r.softwarePaperCitation,
                 license: erc.metadata.o2r.license,
                 author: erc.metadata.o2r.author,
-                viewfiles: erc.metadata.o2r.viewfiles,
+                viewfiles: viewfiles_fix,
                 viewfile: erc.metadata.o2r.viewfile
             };
             return angular.copy(required);

--- a/client/app/o2rHttp/httpRequests.js
+++ b/client/app/o2rHttp/httpRequests.js
@@ -155,8 +155,8 @@
 		}
 
 		function uploadViaSciebo(url, path){
-			var _url = 'http://localhost/api/v1/compendium/';		
-			return $http.post(_url, {content_type:"compendium_v1", share_url:url, path:"/"+path});	
+			var _url = env.api + '/compendium/';		
+			return $http.post(_url, {content_type:"compendium", share_url:url, path:"/"+path});	
 		}
 
 		function toZenodo(compendiumID) {

--- a/client/app/upload/uploadModal.controller.js
+++ b/client/app/upload/uploadModal.controller.js
@@ -51,7 +51,7 @@
         function uploader(file){
             Upload.upload({
                 url: env.api + '/compendium',
-                data: {compendium: file, 'content_type': 'compendium_v1'}
+                data: {compendium: file, 'content_type': 'workspace'}
             })
             .then(successCallback, errorCallback, progress);
             

--- a/test/docker-compose-host-nginx.yml
+++ b/test/docker-compose-host-nginx.yml
@@ -58,22 +58,6 @@ services:
     networks:
       - "o2rnet"
 
-  contentbutler:
-    image: o2rproject/o2r-contentbutler:latest
-    restart: unless-stopped
-    volumes:
-      - o2r_test_storage:/tmp/o2r
-    external_links:
-      - "test_mongodb_1:mongodb"
-    environment:
-      - "CONTENTBUTLER_MONGODB=mongodb://mongodb"
-      - CONTENTBUTLER_PORT=8081
-      - DEBUG=*,-express-session,-compression,-body-parser:*,-mquery,-express:*
-    ports:
-      - "8081:8081"
-    networks:
-      - "o2rnet"
-
   informer:
     image: o2rproject/o2r-informer:latest
     restart: unless-stopped
@@ -129,19 +113,19 @@ services:
     networks:
       - "o2rnet"
 
-  transportar:
-    image: o2rproject/o2r-transportar:latest
+  transporter:
+    image: o2rproject/o2r-transporter:latest
     volumes:
       - o2r_test_storage:/tmp/o2r
       - /var/run/docker.sock:/var/run/docker.sock
     external_links:
       - "test_mongodb_1:mongodb"
     environment:
-      - "TRANSPORTAR_MONGODB=mongodb://mongodb"
-      - TRANSPORTAR_PORT=8086
-      - DEBUG=transportar
+      - "TRANSPORTER_MONGODB=mongodb://mongodb"
+      - TRANSPORTER_PORT=8081
+      - DEBUG=transporter,transporter:*
     ports:
-      - "8086:8086"
+      - "8081:8081"
     networks:
       - "o2rnet"
 

--- a/test/docker-compose-local-platformcontainer.yml
+++ b/test/docker-compose-local-platformcontainer.yml
@@ -58,22 +58,6 @@ services:
     networks:
       - "o2rnet"
 
-  contentbutler:
-    image: contentbutler
-    restart: unless-stopped
-    volumes:
-      - o2r_test_storage:/tmp/o2r
-    external_links:
-      - "test_mongodb_1:mongodb"
-    environment:
-      - "CONTENTBUTLER_MONGODB=mongodb://mongodb"
-      - CONTENTBUTLER_PORT=8081
-      - DEBUG=*
-    ports:
-      - "8081:8081"
-    networks:
-      - "o2rnet"
-
   informer:
     image: informer
     restart: unless-stopped
@@ -129,8 +113,8 @@ services:
     networks:
       - "o2rnet"
 
-  transportar:
-    image: transportar
+  transporter:
+    image: transporter
     restart: unless-stopped
     volumes:
       - o2r_test_storage:/tmp/o2r
@@ -138,11 +122,11 @@ services:
     external_links:
       - "test_mongodb_1:mongodb"
     environment:
-      - "TRANSPORTAR_MONGODB=mongodb://mongodb"
-      - TRANSPORTAR_PORT=8086
-      - DEBUG=transportar
+      - "TRANSPORTER_MONGODB=mongodb://mongodb"
+      - TRANSPORTER_PORT=8081
+      - DEBUG=transporter,transporter:*
     ports:
-      - "8086:8086"
+      - "8081:8081"
     networks:
       - "o2rnet"
 
@@ -174,9 +158,8 @@ services:
     image: nginx:latest
     depends_on:
       - muncher
-      - contentbutler
       - bouncer
-      - transportar
+      - transporter
       - platform
       - informer
       - shipper

--- a/test/docker-compose-local.yml
+++ b/test/docker-compose-local.yml
@@ -58,22 +58,6 @@ services:
     networks:
       - "o2rnet"
 
-  contentbutler:
-    image: contentbutler
-    restart: unless-stopped
-    volumes:
-      - o2r_test_storage:/tmp/o2r
-    external_links:
-      - "test_mongodb_1:mongodb"
-    environment:
-      - "CONTENTBUTLER_MONGODB=mongodb://mongodb"
-      - CONTENTBUTLER_PORT=8081
-      - DEBUG=*
-    ports:
-      - "8081:8081"
-    networks:
-      - "o2rnet"
-
   informer:
     image: informer
     restart: unless-stopped
@@ -129,19 +113,19 @@ services:
     networks:
       - "o2rnet"
 
-  transportar:
-    image: transportar
+  transporter:
+    image: transporter
     volumes:
       - o2r_test_storage:/tmp/o2r
       - /var/run/docker.sock:/var/run/docker.sock
     external_links:
       - "test_mongodb_1:mongodb"
     environment:
-      - "TRANSPORTAR_MONGODB=mongodb://mongodb"
-      - TRANSPORTAR_PORT=8086
-      - DEBUG=transportar
+      - "TRANSPORTER_MONGODB=mongodb://mongodb"
+      - TRANSPORTER_PORT=8081
+      - DEBUG=transporter,transporter:*
     ports:
-      - "8086:8086"
+      - "8081:8081"
     networks:
       - "o2rnet"
 
@@ -166,9 +150,8 @@ services:
     image: nginx:latest
     depends_on:
       - muncher
-      - contentbutler
       - bouncer
-      - transportar
+      - transporter
       - shipper
     volumes:
       - "./nginx.conf:/etc/nginx/nginx.conf:ro"

--- a/test/docker-compose-remote-toolbox.yml
+++ b/test/docker-compose-remote-toolbox.yml
@@ -60,22 +60,6 @@ services:
     networks:
       - "o2rnet"
 
-  contentbutler:
-    image: o2rproject/o2r-contentbutler:latest
-    restart: unless-stopped
-    volumes:
-      - o2r_test_storage:/tmp/o2r
-    external_links:
-      - "test_mongodb_1:mongodb"
-    environment:
-      - "CONTENTBUTLER_MONGODB=mongodb://mongodb"
-      - CONTENTBUTLER_PORT=8081
-      - DEBUG=*,-express-session,-compression,-body-parser:*,-mquery,-express:*
-    ports:
-      - "8081:8081"
-    networks:
-      - "o2rnet"
-
   informer:
     image: o2rproject/o2r-informer:latest
     restart: unless-stopped
@@ -131,8 +115,8 @@ services:
     networks:
       - "o2rnet"
 
-  transportar:
-    image: o2rproject/o2r-transportar:latest
+  transporter:
+    image: o2rproject/o2r-transporter:latest
     restart: unless-stopped
     volumes:
       - o2r_test_storage:/tmp/o2r
@@ -140,11 +124,11 @@ services:
     external_links:
       - "test_mongodb_1:mongodb"
     environment:
-      - "TRANSPORTAR_MONGODB=mongodb://mongodb"
-      - TRANSPORTAR_PORT=8086
-      - DEBUG=transportar
+      - "TRANSPORTER_MONGODB=mongodb://mongodb"
+      - TRANSPORTER_PORT=8081
+      - DEBUG=transporter,transporter:*
     ports:
-      - "8086:8086"
+      - "8081:8081"
     networks:
       - "o2rnet"
 
@@ -178,9 +162,8 @@ services:
     image: nginx:latest
     depends_on:
       - muncher
-      - contentbutler
       - bouncer
-      - transportar
+      - transporter
       - platform
     volumes:
       - "./nginx-platformcontainer.conf:/etc/nginx/nginx.conf:ro"

--- a/test/docker-compose-remote.yml
+++ b/test/docker-compose-remote.yml
@@ -60,22 +60,6 @@ services:
     networks:
       - "o2rnet"
 
-  contentbutler:
-    image: o2rproject/o2r-contentbutler:latest
-    restart: unless-stopped
-    volumes:
-      - o2r_test_storage:/tmp/o2r
-    external_links:
-      - "test_mongodb_1:mongodb"
-    environment:
-      - "CONTENTBUTLER_MONGODB=mongodb://mongodb"
-      - CONTENTBUTLER_PORT=8081
-      - DEBUG=*,-express-session,-compression,-body-parser:*,-mquery,-express:*
-    ports:
-      - "8081:8081"
-    networks:
-      - "o2rnet"
-
   informer:
     image: o2rproject/o2r-informer:latest
     restart: unless-stopped
@@ -131,20 +115,20 @@ services:
     networks:
       - "o2rnet"
 
-  transportar:
+  transporter:
+    image: o2rproject/o2r-transporter:latest
     restart: unless-stopped
-    image: o2rproject/o2r-transportar:latest
     volumes:
       - o2r_test_storage:/tmp/o2r
-      - /var/run/docker.sock:/var/run/docker.sock
+      - "/var/run/docker.sock:/var/run/docker.sock"
     external_links:
       - "test_mongodb_1:mongodb"
     environment:
-      - "TRANSPORTAR_MONGODB=mongodb://mongodb"
-      - TRANSPORTAR_PORT=8086
-      - DEBUG=transportar
+      - "TRANSPORTER_MONGODB=mongodb://mongodb"
+      - TRANSPORTER_PORT=8081
+      - DEBUG=transporter,transporter:*
     ports:
-      - "8086:8086"
+      - "8081:8081"
     networks:
       - "o2rnet"
 
@@ -176,9 +160,8 @@ services:
     image: nginx:latest
     depends_on:
       - muncher
-      - contentbutler
       - bouncer
-      - transportar
+      - transporter
       - platform
     volumes:
       - "./nginx-platformcontainer.conf:/etc/nginx/nginx.conf:ro"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -58,22 +58,6 @@ services:
     networks:
       - "o2rnet"
 
-  contentbutler:
-    image: o2rproject/o2r-contentbutler:latest
-    restart: unless-stopped
-    volumes:
-      - o2r_test_storage:/tmp/o2r
-    external_links:
-      - "test_mongodb_1:mongodb"
-    environment:
-      - "CONTENTBUTLER_MONGODB=mongodb://mongodb"
-      - CONTENTBUTLER_PORT=8081
-      - DEBUG=*,-express-session,-compression,-body-parser:*,-mquery,-express:*
-    ports:
-      - "8081:8081"
-    networks:
-      - "o2rnet"
-
   informer:
     image: o2rproject/o2r-informer:latest
     restart: unless-stopped
@@ -129,19 +113,20 @@ services:
     networks:
       - "o2rnet"
 
-  transportar:
-    image: o2rproject/o2r-transportar:latest
+  transporter:
+    image: o2rproject/o2r-transporter:latest
+    restart: unless-stopped
     volumes:
       - o2r_test_storage:/tmp/o2r
-      - /var/run/docker.sock:/var/run/docker.sock
+      - "/var/run/docker.sock:/var/run/docker.sock"
     external_links:
       - "test_mongodb_1:mongodb"
     environment:
-      - "TRANSPORTAR_MONGODB=mongodb://mongodb"
-      - TRANSPORTAR_PORT=8086
-      - DEBUG=transportar
+      - "TRANSPORTER_MONGODB=mongodb://mongodb"
+      - TRANSPORTER_PORT=8081
+      - DEBUG=transporter,transporter:*
     ports:
-      - "8086:8086"
+      - "8081:8081"
     networks:
       - "o2rnet"
 
@@ -165,9 +150,8 @@ services:
     image: nginx:latest
     depends_on:
       - muncher
-      - contentbutler
       - bouncer
-      - transportar
+      - transporter
     volumes:
       - "./nginx.conf:/etc/nginx/nginx.conf:ro"
       - "../client:/usr/share/nginx/html:ro"

--- a/test/nginx-host-nginx.conf
+++ b/test/nginx-host-nginx.conf
@@ -60,6 +60,11 @@ http {
       proxy_redirect off;
       proxy_set_header Host $host;
     }
+    location ~* \.(zip|tar|tar.gz) {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://localhost:8081;
+    }
 
     location ~* \.io {
       proxy_set_header Host $host;
@@ -91,12 +96,6 @@ http {
       limit_except GET {
         deny all;
       }
-    }
-
-    location ~* \.(zip|tar|tar.gz) {
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://localhost:8086;
     }
 
     location /api/v1/shipment {

--- a/test/nginx-platformcontainer.conf
+++ b/test/nginx-platformcontainer.conf
@@ -59,6 +59,11 @@ http {
       proxy_redirect off;
       proxy_set_header Host $host;
     }
+    location ~* \.(zip|tar|tar.gz) {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://172.17.0.1:8081;
+    }
 
     location ~* \.io {
       proxy_set_header Host $host;
@@ -90,12 +95,6 @@ http {
       limit_except GET {
         deny all;
       }
-    }
-
-    location ~* \.(zip|tar|tar.gz) {
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:8086;
     }
 
     location /api/v1/shipment {

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -60,7 +60,12 @@ http {
       proxy_redirect off;
       proxy_set_header Host $host;
     }
-
+    location ~* \.(zip|tar|tar.gz) {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://172.17.0.1:8081;
+    }
+    
     location ~* \.io {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -91,12 +96,6 @@ http {
       limit_except GET {
         deny all;
       }
-    }
-
-    location ~* \.(zip|tar|tar.gz) {
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:8086;
     }
 
     location /api/v1/shipment {


### PR DESCRIPTION
This updates the platform to support the latest versions of o2r-muncher and o2r-loader, most notably with the "candidate" mechanism and workspace support.

Also, the microservices o2r-contentbutler and o2r-transportar have been merged into o2r-transporter.