### PR TITLE
Improvements to docker-compose config, admin view, and ORCID usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,16 @@ By default, users may create compendia, but if you want to develop features for 
 
 ## Proxy for o2r microservices
 
-If you run the o2r microservices locally as a developer, it is useful to run a local nginx to make all API endpoints available under one port (`80`), and use the same nginx to serve the application in this repo.
-A nginx configuration file to achieve this is `dev/nginx-microservices.conf`.
+If you run the o2r microservices locally as a developer (e.g. by manually starting each microservice via `npm start`), it is useful to run a local nginx to make all API endpoints available under one port (`80`), and use the same nginx to serve the application in this repo.
+A nginx configuration file to achieve this is **`dev/nginx-microservices.conf`**.
 
 ```bash
-#sed -i -e 's|http://o2r.uni-muenster.de/api/v1|http://localhost/api/v1|g' js/app.js
-docker run --rm --name o2r-platform -p 80:80 -v $(pwd)/test/nginx.conf:/etc/nginx/nginx.conf -v $(pwd)/client:/etc/nginx/html $(pwd)/test:/etc/nginx/html/test nginx
+docker run --rm --name o2r-platform --network="host" -p 80:80 -v $(pwd)/dev/nginx-microservices.conf:/etc/nginx/nginx.conf:ro -v $(pwd)/client:/usr/share/nginx/html:ro -v $(pwd)/dev:/etc/nginx/html/dev:ro nginx:stable-alpine
+
+# bash inside the container for debugging IPs:
+docker exec -it o2r-platform /bin/bash
+# get the host machine IP from inside the container (use this if the default 172.17.0.1 does not work):
+ip addr show docker0 | grep -Po 'inet \K[\d.]+'
 ```
 
 Note: If you want to run this in a Makefile, `$(CURDIR)` will come in handy to create the mount paths instead of using `$(pwd)`.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Note: If you want to run this in a Makefile, `$(CURDIR)` will come in handy to c
 
 ## WebSocket testing
 
-The compose configuration also makes a simple test page for WebSockets available at http://localhost/dev/socket.html (file (`dev/socket.html`)).
+The compose configuration also makes a simple test page for WebSockets available at http://localhost/dev/socket.html (based on file `dev/socket.html`).
 
 ## Platform Version
 

--- a/client/app/adminView/admin.html
+++ b/client/app/adminView/admin.html
@@ -11,8 +11,8 @@
                     <label>Search</label>
                     <input ng-model="vm.searchText">
                 </md-input-container>
-                <table>
-                    <tr><th>User Name</th><th>User Id</th><th>User Group</th><th></th></tr>
+                <table width="100%">
+                    <thead align="left"><tr><th>Name</th><th>Id</th><th>Level</th><th></th></tr></thead>
                     <tr ng-repeat="user in vm.users | filter:vm.searchText">
                         <td>
                             <md-input-container>
@@ -26,12 +26,12 @@
                         </td>
                         <td>
                             <md-input-container>
-                                <label>User Group</label>
+                                <label>Level</label>
                                 <md-select ng-model="user.level">
-                                    <md-option ng-value="vm.levels.users">New Users</md-option>
-                                    <md-option ng-value="vm.levels.knowns">Known Users</md-option>
-                                    <md-option ng-value="vm.levels.editors">Editors</md-option>
-                                    <md-option ng-value="vm.levels.admins">Admins</md-option>
+                                    <md-option ng-value="vm.levels.users">New User</md-option>
+                                    <md-option ng-value="vm.levels.knowns">Known User</md-option>
+                                    <md-option ng-value="vm.levels.editors">Editor</md-option>
+                                    <md-option ng-value="vm.levels.admins">Admin</md-option>
                                 </md-select>
                             </md-input-container>
                         </td>
@@ -45,23 +45,11 @@
         <md-card>
             <md-card-title>
                 <md-card-title-text>
-                    <span class="md-headline">Description of user groups</span>
+                    <span class="md-headline">User levels</span>
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-                So far, there are 4 possible user groups. <br> 
-                See a detailed description of <strong>permissions</strong> below. 
-                <h2 class="md-headline">New Users</h2>
-                Create new jobs. View compendia, jobs, user details.
-                <md-divider></md-divider>
-                <h2 class="md-headline">Known Users</h2>
-                Upload new compendium. Create shipments. Create substitutions.
-                <md-divider></md-divider>
-                <h2 class="md-headline">Editors</h2>
-                Edit user levels. Edit metadata of other user's compendia.
-                <md-divider></md-divider>
-                <h2 class="md-headline">Admins</h2>
-                View status pages of microservices.
+                The o2r Web API requires specific <em>user levels</em> for some actions, such as creating or shipping compendia. A list of levels and their permissions is available <a href="http://o2r.info/o2r-web-api/user/#user-levels">here</a>.
             </md-card-content>
         </md-card>
     </div>

--- a/client/app/authorView/author.controller.js
+++ b/client/app/authorView/author.controller.js
@@ -82,8 +82,8 @@
                         .htmlContent(
                             '<table>' + 
                             '<tr><td>Name: </td><td>' + author.data.name + '</td></tr>' +
-                            '<tr><td>Orcid: </td><td>' + author.data.id + '</td></tr>' +
-                            '<tr><td>User Group: </td><td>' + getUserGroup(author.data.level) + '</td></tr>' +
+                            '<tr><td>ORCID: </td><td><img src="https://members.orcid.org/sites/default/files/vector_iD_icon.svg" alt="ORCID icon" height="12" />&nbsp;<a href="https://orcid.org/' + author.data.id + '">orcid.org/' + author.data.id + '</a></td></tr>' +
+                            '<tr><td>Level (<a href="http://o2r.info/o2r-web-api/user/#user-levels" title="Information about user levels">?</a>): </td><td>' + getUserGroup(author.data.level) + '</td></tr>' +
                             '</table>' +
                             '<br><br>If you want to change your user level, please send an email to daniel.nuest@uni-muenster.de.'
                         )
@@ -93,10 +93,10 @@
             }
 
             function getUserGroup(level){
-                if(level >= env.userLevels.admins) return 'Admins';
-                if(level >= env.userLevels.editors) return 'Editors'
-                if(level >= env.userLevels.knowns) return 'Known Users';
-                if(level >= env.userLevels.users) return 'New Users';
+                if(level >= env.userLevels.admins) return 'Admin';
+                if(level >= env.userLevels.editors) return 'Editor'
+                if(level >= env.userLevels.knowns) return 'Known User';
+                if(level >= env.userLevels.users) return 'New User';
             }
 
         }

--- a/client/app/creationProcess/requiredMetadata.html
+++ b/client/app/creationProcess/requiredMetadata.html
@@ -62,7 +62,7 @@
                     <input ng-model="vm.author.affiliation" ng-value="vm.required.author[vm.editAuthor].affiliation">
                 </md-input-container>
                 <md-input-container>
-                    <label>Orcid</label>
+                    <label>ORCID</label>
                     <input ng-model="vm.author.orcid" ng-value="vm.required.author[vm.editAuthor].orcid">
                 </md-input-container>
                 <md-button class="md-raised" ng-click="vm.updateAuthor(vm.editAuthor)" aria-label="Update Author">
@@ -86,7 +86,7 @@
                     <input ng-model="vm.author.affiliation">
                 </md-input-container>
                 <md-input-container>
-                    <label>Orcid</label>
+                    <label>ORCID</label>
                     <input ng-model="vm.author.orcid">
                 </md-input-container>
                 <md-button class="md-raised" ng-disabled="requiredForm.authorname.$invalid" ng-click="vm.addNewAuthor()" aria-label="Add Author">

--- a/client/app/homeView/home.controller.js
+++ b/client/app/homeView/home.controller.js
@@ -29,7 +29,7 @@
             steps: [
             {
                 element: '#o2r-login',
-                intro: 'Login with your Orcid Account, for uploading ERCs, etc...'
+                intro: 'Login with your ORCID identifier <a href="https://orcid.org"><img src="https://members.orcid.org/sites/default/files/vector_iD_icon.svg" alt="ORCID iD icon" height="12" /></a>, for uploading ERCs, etc...'
             },
             {
                 element: '#home-create-erc',

--- a/client/app/o2rMetadataView/o2rMetadataView.template.html
+++ b/client/app/o2rMetadataView/o2rMetadataView.template.html
@@ -14,7 +14,7 @@
                             <p layout="column">
                                 {{author.name}} 
                                 <span>{{affiliation}}</span>
-                                <span ng-if="notNull(author.orcid) && !isUndefined(author.orcid)">Orcid: {{author.orcid}}</span>
+                                <span ng-if="notNull(author.orcid) && !isUndefined(author.orcid)">ORCID: {{author.orcid}}</span>
                             </p>
                         </div>
                         <!-- End Author Information -->

--- a/dev/nginx-microservices.conf
+++ b/dev/nginx-microservices.conf
@@ -1,4 +1,4 @@
-# ngninx configuration to proxy manually started microservices under one port
+# ngninx configuration to proxy manually started microservices under one port and host the client application at "/".
 
 worker_processes 3;
 
@@ -25,12 +25,12 @@ http {
       #The location setting lets you configure how nginx responds to requests for resources within the server.
       include  /etc/nginx/mime.types;
       root   /usr/share/nginx/html;
-      index  index.html index.htm;
+      index  index.html;
     }
 
     # use default Docker host IP for the microservices that run outside of this container, see ifconfig
     location /api {
-      proxy_pass http://localhost:8080;
+      proxy_pass http://172.17.0.1:8080;
       proxy_redirect off;
       proxy_set_header Host $host;
     }
@@ -56,14 +56,15 @@ http {
     }
 
     location ~ /data/ {
-      proxy_pass http://localhost:8081;
+      proxy_pass http://172.17.0.1:8081;
       proxy_redirect off;
       proxy_set_header Host $host;
     }
+
     location ~* \.(zip|tar|tar.gz) {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://localhost:8081;
+      proxy_pass http://172.17.0.1:8081;
     }
 
     location ~* \.io {
@@ -72,25 +73,25 @@ http {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
       
-      proxy_pass http://localhost:8082;
+      proxy_pass http://172.17.0.1:8082;
     }
 
     location /api/v1/auth/ {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://localhost:8083;
+      proxy_pass http://172.17.0.1:8083;
     }
 
     location /api/v1/user/ {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://localhost:8083;
+      proxy_pass http://172.17.0.1:8083;
     }
 
     location /api/v1/search {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://localhost:9200/o2r/compendia/_search;
+      proxy_pass http://172.17.0.1:9200/o2r/compendia/_search;
 
       # for requests other than GET you must enter the container
       limit_except GET {
@@ -101,13 +102,13 @@ http {
     location /api/v1/shipment {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://localhost:8087;
+      proxy_pass http://172.17.0.1:8087;
     }
 
     location /api/v1/substitution {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://localhost:8090;
+      proxy_pass http://172.17.0.1:8090;
     }
   }
 }

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -25,45 +25,45 @@ http {
       #The location setting lets you configure how nginx responds to requests for resources within the server.
       include  /etc/nginx/mime.types;
       root   /usr/share/nginx/html;
-      index  index.html index.htm;
+      index  index.html;
     }
 
     # use default Docker host IP for the microservices that run outside of this container, see ifconfig
     location /api {
-      proxy_pass http://172.17.0.1:8080;
+      proxy_pass http://muncher:8080;
       proxy_redirect off;
       proxy_set_header Host $host;
     }
 
     # pass all ../metadata requests to muncher
     location ~* ^/api/v1/compendium/[^/]+/metadata {
-      proxy_pass http://172.17.0.1:8080;
+      proxy_pass http://muncher:8080;
       proxy_redirect off;
       proxy_set_header Host $host;
     }
 
     # split endpoint between loader for POSTs and muncher for all other operations
     location /api/v1/compendium {
-      proxy_pass http://172.17.0.1:8088;
+      proxy_pass http://loader:8088;
       proxy_redirect off;
       proxy_set_header Host $host;
       proxy_read_timeout 30m;
 
       # For requests that *are not* a POST, pass to muncher
       limit_except POST {
-        proxy_pass http://172.17.0.1:8080;
+        proxy_pass http://muncher:8080;
       }
     }
 
     location ~ /data/ {
-      proxy_pass http://172.17.0.1:8081;
+      proxy_pass http://transporter:8081;
       proxy_redirect off;
       proxy_set_header Host $host;
     }
     location ~* \.(zip|tar|tar.gz) {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:8081;
+      proxy_pass http://transporter:8081;
     }
     
     location ~* \.io {
@@ -72,25 +72,25 @@ http {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
       
-      proxy_pass http://172.17.0.1:8082;
+      proxy_pass http://informer:8082;
     }
 
     location /api/v1/auth/ {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:8083;
+      proxy_pass http://bouncer:8083;
     }
 
     location /api/v1/user/ {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:8083;
+      proxy_pass http://bouncer:8083;
     }
 
     location /api/v1/search {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:9200/o2r/compendia/_search;
+      proxy_pass http://elasticsearch:9200/o2r/compendia/_search;
 
       # for requests other than GET you must enter the container
       limit_except GET {
@@ -101,13 +101,13 @@ http {
     location /api/v1/shipment {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:8087;
+      proxy_pass http://shipper:8087;
     }
 
     location /api/v1/substitution {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:8090;
+      proxy_pass http://substituter:8090;
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ volumes:
 services:
   mongodb:
     image: mongo:3.4
-    ports:
-      - "27017:27017"
     command: "--replSet rso2r"
 
   mongodbconfig:
@@ -34,9 +32,11 @@ services:
 
   mongoadmin:
     image: adicom/admin-mongo:latest
+    depends_on:
+      - mongodb
     environment:
       - DB_HOST=mongodb
-      - CONN_NAME=Local 
+      - CONN_NAME=Local
     ports:
       - "1234:1234"
 
@@ -44,9 +44,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.3
     environment:
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
-    ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "xpack.security.enabled=false"
 
   muncher:
     image: o2rproject/o2r-muncher:latest
@@ -58,12 +56,12 @@ services:
       - "MUNCHER_MONGODB=mongodb://mongodb"
       - MUNCHER_PORT=8080
       - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
-    ports:
-      - "8080:8080"
 
   loader:
     image: o2rproject/o2r-loader:latest
     restart: unless-stopped
+    depends_on:
+      - mongodbconfig
     volumes:
       - o2rstorage:/tmp/o2r
       - /var/run/docker.sock:/var/run/docker.sock
@@ -71,23 +69,23 @@ services:
       - "LOADER_MONGODB=mongodb://mongodb"
       - LOADER_PORT=8088
       - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
-    ports:
-      - "8088:8088"
 
   informer:
     image: o2rproject/o2r-informer:latest
     restart: unless-stopped
+    depends_on:
+      - mongodbconfig
     environment:
       - "INFORMER_MONGODB=mongodb://mongodb"
       - INFORMER_MONGODB_HOST=mongodb
       - INFORMER_PORT=8082
       - DEBUG=informer
-    ports:
-      - "8082:8082"
 
   bouncer:
     image: o2rproject/o2r-bouncer:latest
     restart: unless-stopped
+    depends_on:
+      - mongodbconfig
     environment:
       - "BOUNCER_MONGODB=mongodb://mongodb"
       - BOUNCER_PORT=8083
@@ -97,28 +95,30 @@ services:
       - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
       - SLACK_VERIFICATION_TOKEN=${SLACK_VERIFICATION_TOKEN}
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
-    ports:
-      - "8083:8083"
 
   finder:
     image: o2rproject/o2r-finder:latest
     restart: unless-stopped
+    depends_on:
+      - mongodb
+      - mongodbconfig
+      - elasticsearch
     volumes:
       - o2rstorage:/tmp/o2r
     environment:
       - "FINDER_MONGODB_USER_DATABASE=mongodb://mongodb/muncher"
       - FINDER_PORT=8084
-      - DEBUG=finder
+      - DEBUG=finder,finder:*
       - ELASTIC_SEARCH_URL=elasticsearch:9200
       - "MONGO_DATA_URL=mongodb://mongodb/muncher"
       - "MONGO_OPLOG_URL=mongodb://mongodb/muncher"
       - BATCH_COUNT=20
-    ports:
-      - "8084:8084"
 
   transporter:
     image: o2rproject/o2r-transporter:latest
     restart: unless-stopped
+    depends_on:
+      - mongodbconfig
     volumes:
       - o2rstorage:/tmp/o2r
       - "/var/run/docker.sock:/var/run/docker.sock"
@@ -126,11 +126,12 @@ services:
       - "TRANSPORTER_MONGODB=mongodb://mongodb"
       - TRANSPORTER_PORT=8081
       - DEBUG=transporter,transporter:*
-    ports:
-      - "8081:8081"
 
   shipper:
     image: o2rproject/o2r-shipper:latest
+    restart: unless-stopped
+    depends_on:
+      - mongodbconfig
     volumes:
       - o2rstorage:/tmp/o2r
     environment:
@@ -138,31 +139,34 @@ services:
       - SHIPPER_REPO_ZENODO_TOKEN=${ZENODO_TOKEN}
       - "SHIPPER_BOTTLE_HOST=0.0.0.0"
       - "SHIPPER_BASE_PATH=/tmp/o2r"
-    ports:
-      - "8087:8087"
 
   substituter:
     image: o2rproject/o2r-substituter:latest
     restart: unless-stopped
+    depends_on:
+      - mongodbconfig
     volumes:
       - o2rstorage:/tmp/o2r
     environment:
       - "SUBSTITUTER_MONGODB=mongodb://mongodb"
       - SUBSTITUTER_PORT=8090
       - DEBUG=substituter,substituter:*
-    ports:
-      - "8090:8090"
 
   platform:
     image: nginx:latest
     depends_on:
-      - muncher
       - bouncer
+      - finder
+      - muncher
+      - informer
+      - loader
       - transporter
+      - shipper
+      - substituter
     volumes:
       - "./dev/nginx.conf:/etc/nginx/nginx.conf:ro"
-      - "./client:/usr/share/nginx/html"
       - "./dev/socket.html:/usr/share/nginx/html/dev/socket.html:ro"
+      - "./client:/usr/share/nginx/html:ro"
       #- "./dev/config-toolbox.js:/etc/nginx/html/app/config/config.js:ro"
     ports:
       - "80:80"


### PR DESCRIPTION
Partially as a test if development works well with the new compose configuration I made some changes...

## docker-compose

The configuration does not expose any ports and uses proper host names. One user had an issue where the host IP was (for whatever reason) not the default `172.17.0.1`. This can now not happen anymore. Also, for UI dev there is no need to access the DB and microservices directly.

## Admin view

Using the term "level" throughout, and some minor changes. Also, no replicating the information but linkint tothe API docs. We can provide more user friendly info at a later point, now I'd prefer to have a single point of change.

## ORCID

Following the trademark guidelines here () I made some changes to (a) the profile view

![image](https://user-images.githubusercontent.com/1325054/31727902-2885ae4e-b42b-11e7-872b-a139978224e1.png)

and (b) the intro

![image](https://user-images.githubusercontent.com/1325054/31728026-7e013f0a-b42b-11e7-8f1a-772fc8d2b81b.png)

