### PR TITLE
update candidate view and file magnifier before substitution

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -5,6 +5,7 @@
         .module('starter', [
             "conf",
             "starter.o2rDisplayFiles",
+            "starter.o2rSubstituteCandidate",
             "starter.o2rCompare",
             "starter.o2rHttp",
             "starter.o2rInspect",
@@ -37,7 +38,7 @@
     function config($stateProvider, $urlRouterProvider, $mdThemingProvider, $logProvider, $analyticsProvider, hljsServiceProvider, $compileProvider, $mdDateLocaleProvider, $sceDelegateProvider, env, logEnhancerProvider){
         $compileProvider.preAssignBindingsEnabled(true);
 
-        $sceDelegateProvider.resourceUrlWhitelist(['self', 'https://markuskonkol.shinyapps.io/main/', 'https://markuskonkol.shinyapps.io/mjomeiAnalysis2/', 'https://markuskonkol.shinyapps.io/figure1_interactive', 
+        $sceDelegateProvider.resourceUrlWhitelist(['self', 'https://markuskonkol.shinyapps.io/main/', 'https://markuskonkol.shinyapps.io/mjomeiAnalysis2/', 'https://markuskonkol.shinyapps.io/figure1_interactive',
         'https://markuskonkol.shinyapps.io/figure1_interactive/', 'https://markuskonkol.shinyapps.io/interactiveFigure1/']);
         /* eslint-disable angular/window-service, angular/log */
         $analyticsProvider.developerMode(env.disableTracking);

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -6,6 +6,7 @@
             "conf",
             "starter.o2rDisplayFiles",
             "starter.o2rSubstituteCandidate",
+            "starter.o2rSubstituteMagnify",
             "starter.o2rCompare",
             "starter.o2rHttp",
             "starter.o2rInspect",
@@ -309,7 +310,8 @@
             {name: 'assignment', category: 'action', fn: 'assignment'},
             {name: 'compass', category: 'action', fn: 'explore'},
             {name: 'folder', category: 'file', fn: 'folder'},
-            {name: 'substitution_options', category: 'action', fn: 'swap_horiz_black'}
+            {name: 'substitution_options', category: 'action', fn: 'swap_horiz_black'},
+            {name: 'backArrow', category: 'navigation', fn: 'arrow_back'}
         ];
 
         for(var i in icons){

--- a/client/app/ercView/erc.controller.js
+++ b/client/app/ercView/erc.controller.js
@@ -5,13 +5,13 @@
         .module('starter')
         .controller('ErcController', ErcController);
 
-    ErcController.$inject = ['$scope', '$stateParams', '$log', '$state', 'erc', 'publications', 'icons', 'header', '$mdSidenav', 'env', 'ngProgressFactory', 'httpRequests', 'login'];
-    function ErcController($scope, $stateParams, $log, $state, erc, publications, icons, header, $mdSidenav, env, ngProgressFactory, httpRequests, login){
+    ErcController.$inject = ['$scope', '$stateParams', '$log', '$state', '$window', 'erc', 'publications', 'icons', 'header', '$mdSidenav', 'env', 'ngProgressFactory', 'httpRequests', 'login'];
+    function ErcController($scope, $stateParams, $log, $state, $window, erc, publications, icons, header, $mdSidenav, env, ngProgressFactory, httpRequests, login){
         var logger = $log.getInstance('ErcCtrl');
         var defView = {};
         defView.state = 'erc.reproduce';
         defView.name = 'reproduce';
-        
+
         var vm = this;
         vm.icons = icons;
         vm.server = env.server;
@@ -51,6 +51,17 @@
         vm.sendToZenodo = sendToZenodo;
         vm.publishInZenodo = publishInZenodo;
 
+        // only necessary for substitited ERC
+        vm.showERC = showERC;
+        vm.substitution = {};
+        if (vm.publication.metadata.substituted) {
+            vm.substitution.substituted = vm.publication.metadata.substituted;
+            vm.substitution.baseID = vm.publication.metadata.substitution.base;
+            vm.substitution.overlayID = vm.publication.metadata.substitution.overlay;
+        } else {
+            vm.substitution.substituted = false;
+        }
+
         logger.info(vm.publication);
 
         activate();
@@ -63,11 +74,16 @@
             getShipment();
         }
 
+        function showERC(url) {
+            let url_ = "#!/erc/" + url;
+            $window.open(url_);
+        }
+
         function getShipment(){
             httpRequests.getShipment(vm.ercId)
                 .then(function (res){
                     logger.info(res);
-                    if(res.data.length > 0){ 
+                    if(res.data.length > 0){
                         vm.shipped=true;
                         httpRequests.getStatus(res.data[0])
                         .then(function (res2){
@@ -77,7 +93,7 @@
                             }
                             if (res2.data.status == "published"){
                                 vm.publish = true;
-                            }    
+                            }
                         })
                         .catch(function (err2){
                             logger.info(err2);
@@ -103,7 +119,7 @@
 			})
             .catch(function (err){
                 logger.info(err);
-            })     
+            })
         }
 
         function publishInZenodo(){
@@ -111,8 +127,8 @@
                 .then(function (res){
                     httpRequests.publishERC(res.data[0])
                     .then(function (res2){
-                        logger.info("published")  
-                        logger.info(res2) 
+                        logger.info("published")
+                        logger.info(res2)
                     })
                     .catch(function (err2){
                         logger.info(err2);
@@ -153,8 +169,8 @@
         }
 
         /**
-         * 
-         * @param {Object} obj, expects an object with two attributes: code, data. Each attribute is an array 
+         *
+         * @param {Object} obj, expects an object with two attributes: code, data. Each attribute is an array
          */
         function mSetCodeData(obj){
             vm.mCodeData = obj;

--- a/client/app/ercView/erc.html
+++ b/client/app/ercView/erc.html
@@ -1,5 +1,10 @@
 <!-- Top nav -->
 <div flex="100" layout="row">
+    <div ng-if="vm.substitution.substituted">
+      <md-button title="what is a substitution?" href="http://o2r.info/o2r-web-api/compendium/substitute/" target="_blank" style="background-color:#CE5100">THIS IS A SUBSTITUTION</md-button>
+      <a href="" ng-click="vm.showERC(vm.substitution.baseID)">base compendium</a>
+      <a href="" ng-click="vm.showERC(vm.substitution.overlayID)">overlay compendium</a>
+    </div>
     <span flex></span>
     <md-button ng-if="vm.loggedIn" ng-disabled="vm.shipped" ng-click="vm.sendToZenodo()" aria-label="Ship to Zenodo">Ship to Zenodo<md-icon aria-label md-svg-src="{{vm.icons.rowing}}"></md-icon></md-button>
 	<md-button ng-if="vm.loggedIn" ng-disabled="vm.publish" ng-click="vm.publishInZenodo()" aria-label="Publish in Zenodo">Publish in Zenodo</md-button>
@@ -77,7 +82,7 @@
         </md-card-header>
         <md-card-content>
             <o2r-display-files o2r-file="{{vm.file}}"></o2r-display-files>
-        </md-card-content>   
+        </md-card-content>
     </md-card>
 
     <!-- CodeDataView for manipulateView -->

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
@@ -61,10 +61,10 @@
 					scope.addDropdown = addDropdown;
 					scope.magnifyFiles = magnifyFiles;
 					scope.metadata = {};
-					scope.metadata.selected = 'keep';
+					scope.metadata.selected = 'keepBase';
 					scope.metadata.data = [
-							{label: 'keep metadata of base ERC', value: 'keep'},
-							{label: 'extract metadata for new ERC', value: 'extract', isDisabled: true}
+							{label: 'keep metadata of base ERC', value: 'keepBase'},
+							{label: 'extract and merge metadata for new ERC', value: 'extractAndMerge', isDisabled: true}
 					];
 
 					function cancel() {
@@ -84,6 +84,7 @@
 		              let substitutionMetadata = {};
 		              let arrayOfSubstitutionObjects = [];
 
+		              substitutionMetadata.metadataHandling = scope.metadata.selected;
 		              substitutionMetadata.base = scope.o2rBaseId;
 		              substitutionMetadata.overlay = scope.o2rOverlayId;
 		              substitutionMetadata.substitutionFiles = [];

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
@@ -2,26 +2,22 @@
 	'use strict';
 
 	/*
-		Directive for displaying different file types.
+		Directive for candidate view.
 		This directive checks the mime type attribute of a publication.content.<element> to handle it differently considering its mime type.
-		Directive can only be used as Html-Element and expects an attribute o2r-file.
-		o2r-file must be an object with at least following attribute:
+		Directive can only be used as Html-Element and expects attributes o2r-base, o2r-overlay, o2r-base-title, o2r-overlay-title, o2r-base-id, o2r-overlay-id.
+		o2r-base-title, o2r-overlay-title, o2r-base-id, o2r-overlay-id must be a String.
+		o2r-base and o2r-overlay must be an array with at least one object with following attribute:
 
-		{
-		path: String
-		}
+		[
+			{
+				fileName: String
+				filePath: String
+				uId: Number
+			}
+		]
 
 		Example:
-		<o2r-display-files o2r-file="{'path': 'foo/bar'}"></o2r-display-files>
-
-		optional attributes:
-
-		{
-			size: Integer,
-			type: String
-		}
-
-		where size is the filesize in bytes and type is the mime type.
+		<o2r-substitute-candidate o2r-base="[{fileName: 'foo', filePath: 'bar', uId: '1'}]" o2r-overlay="[{fileName: 'foo', filePath: 'bar', uId: '1'}]" o2r-base-title="{{'foobar'}}" o2r-overlay-title="{{'barfoo'}}" o2r-base-id="{{'foo'}}" o2r-overlay-id="{{'bar'}}"></o2r-substitute-candidate>
 	*/
 	angular
 		.module('starter.o2rSubstituteCandidate', [])

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
@@ -59,6 +59,7 @@
 					scope.selectSubstitutionFiles = selectSubstitutionFiles;
 					scope.delDropdown = delDropdown;
 					scope.addDropdown = addDropdown;
+					scope.magnifyFiles = magnifyFiles;
 
 					function cancel() {
 					    scope.substitutionRows = [{}];
@@ -109,6 +110,17 @@
 					function showSubstitutedERC() {
 							$window.open(scope.substituted.url);
 					};
+
+					function magnifyFiles(ev, data){
+							$mdDialog.show({
+									template: '<md-dialog class="substitute_magnifier"><o2r-substitute-magnify o2r-base-file="'+data.fileSelectBase.filePath+'" o2r-overlay-file="'+data.fileSelectOverlay.filePath+'" o2r-overlay-id="'+scope.o2rOverlayId+'"></o2r-substitute-magnify></md-dialog>',
+									parent: angular.element(document.body),
+									targetEvent: ev,
+									fullscreen: true,
+									clickOutsideToClose: false,
+									multiple: true
+							});
+					}
 
 		      // on change of dropdown list
 		       function selectSubstitutionFiles(file, type, row) {

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
@@ -1,0 +1,181 @@
+(function(){
+	'use strict';
+
+	/*
+		Directive for displaying different file types.
+		This directive checks the mime type attribute of a publication.content.<element> to handle it differently considering its mime type.
+		Directive can only be used as Html-Element and expects an attribute o2r-file.
+		o2r-file must be an object with at least following attribute:
+
+		{
+		path: String
+		}
+
+		Example:
+		<o2r-display-files o2r-file="{'path': 'foo/bar'}"></o2r-display-files>
+
+		optional attributes:
+
+		{
+			size: Integer,
+			type: String
+		}
+
+		where size is the filesize in bytes and type is the mime type.
+	*/
+	angular
+		.module('starter.o2rSubstituteCandidate', [])
+		.directive('o2rSubstituteCandidate', o2rSubstituteCandidate);
+
+	o2rSubstituteCandidate.$inject= ['$log', 'env', 'icons', '$mdDialog', 'httpRequests'];
+	function o2rSubstituteCandidate($log, env, icons, $mdDialog, httpRequests){
+		return{
+			restrict: 'E',
+			templateUrl: 'app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html',
+			scope: {
+				o2rBase: '=',
+				o2rOverlay: '=',
+				o2rBaseTitle: '@',
+				o2rOverlayTitle: '@',
+				o2rBaseId: '@',
+				o2rOverlayId: '@'
+			},
+			link: link
+		};
+
+		function link(scope, iElement, attrs){
+			var logger = $log.getInstance('SubstituteCtrl');
+			var vm = this;
+
+			scope.icons = icons;
+			scope.substitutionRows = [{}];
+			scope.baseType = "base";
+			scope.overlayType = "overlay";
+
+			attrs.$observe('o2rOverlayTitle', function(val_) {
+				if(val_ != '') {
+
+					scope.cancel = cancel;
+					scope.startSubstitutionUI = startSubstitutionUI;
+					scope.selectSubstitutionFiles = selectSubstitutionFiles;
+					scope.delDropdown = delDropdown;
+					scope.addDropdown = addDropdown;
+
+					function cancel() {
+					    scope.substitutionRows = [{}];
+							$mdDialog.cancel();
+					};
+
+					// TODO: start substitution UI
+		       function startSubstitutionUI() {
+		          logger.info("initiateSubstitution");
+		          logger.debug("initiateSubstitution");
+
+		          if (!Array.isArray(scope.substitutionRows) || scope.substitutionRows == undefined || scope.substitutionRows.length == 0 || !checkForFiles(scope.substitutionRows)) {
+		              logger.info("no substitution files choosen");
+		              window.alert("please choose files");
+		          } else {
+		              $mdDialog.hide();
+		              logger.info("init substitution");
+		              // start substitution
+
+		              let substitutionMetadata = {};
+		              let arrayOfSubstitutionObjects = [];
+
+		              substitutionMetadata.base = scope.o2rBaseId;
+		              substitutionMetadata.overlay = scope.o2rOverlayId;
+		              substitutionMetadata.substitutionFiles = [];
+
+		              for (let i=0; i<scope.substitutionRows.length; i++) {
+		                let object_ = {};
+		                object_.base = scope.substitutionRows[i].basefile.filePath;
+		                object_.overlay = scope.substitutionRows[i].overlayfile.filePath;
+		                substitutionMetadata.substitutionFiles.push(object_);
+		              }
+
+									cancel();	// close dialog and delete substitutionRows
+
+									logger.debug("substitution with following metadata: %s", JSON.stringify(substitutionMetadata));
+
+		              httpRequests.substitute(substitutionMetadata)
+		                .then(function(res){
+		                    logger.info(res);
+		                    window.alert("substitution finished");
+		                })
+		                .catch(function(err){
+											logger.info(err);
+											window.alert("Error while substitution:\n" + err.data.err);
+		                });
+		          }
+		      };
+		      // on change of dropdown list
+		       function selectSubstitutionFiles(file, type, row) {
+		          let i = row.$index;
+		          let o2rBaseLength = scope.o2rBase.length;
+		          let o2rOverlayLength = scope.o2rOverlay.length;
+		          let oldBaseCandidatePosition; // = scope.substitutionRows[i].basefile.uId;
+		          let newBaseCandidatePosition;
+		          let oldOverlayCandidatePosition; // = scope.substitutionRows[i].overlayfile.uId;
+		          let newOverlayCandidatePosition;
+
+		          // change "selected" to TRUE of new file
+		          if (type == "base") {
+		              newBaseCandidatePosition = file.uId;
+		              // change "selected" to FALSE of exchanged file
+		              if (scope.substitutionRows[i].basefile != undefined) {
+		                  oldBaseCandidatePosition = scope.substitutionRows[i].basefile.uId;
+		                  scope.o2rBase[oldBaseCandidatePosition-1].selected = false;
+		              }
+		              scope.substitutionRows[i].basefile = file;
+		              scope.o2rBase[newBaseCandidatePosition-1].selected = true;
+		          }
+		          if (type == "overlay") {
+		              newOverlayCandidatePosition = file.uId;
+		              // change "selected" to FALSE of exchanged file
+		              if (scope.substitutionRows[i].overlayfile != undefined) {
+		                  oldOverlayCandidatePosition = scope.substitutionRows[i].overlayfile.uId;
+		                  scope.o2rOverlay[oldOverlayCandidatePosition-1].selected = false;
+		              }
+		              scope.substitutionRows[i].overlayfile = file;
+		              scope.o2rOverlay[newOverlayCandidatePosition-1].selected = true;
+		          }
+		      };
+
+		      function checkForFiles(array) {
+		        // true = contains files , false = no files
+		          if (Array.isArray(array)) {
+		              for (let i=0; i<array.length; i++) {
+		                  if (typeof(array[i].basefile) != "object" || typeof(array[i].overlayfile) != "object") {
+		                      return false;
+		                  }
+		              }
+		              return true;
+		          }
+		          return false;
+		      };
+
+		      function delDropdown(row) {
+		          var i = row.$index;
+		          if (scope.substitutionRows.length <= 1) {
+		              // TODO: button in red to warn
+		          } else {
+		            scope.substitutionRows.splice(i, 1);
+		          }
+		      };
+
+		      function addDropdown() {
+		        if ((scope.substitutionRows.length == scope.o2rBase.length) || (scope.substitutionRows.length == scope.o2rOverlay.length)) {
+		          // TODO: button in red to warn
+		        } else {
+		          scope.substitutionRows.push({});
+		        }
+		      };
+
+				}
+			});
+
+		}
+
+
+	}
+})(window.angular);

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
@@ -64,6 +64,7 @@
 					scope.metadata.selected = 'keepBase';
 					scope.metadata.data = [
 							{label: 'keep metadata of base ERC', value: 'keepBase'},
+							{label: 'extract metadata of new ERC', value: 'extract', isDisabled: true},
 							{label: 'extract and merge metadata for new ERC', value: 'extractAndMerge', isDisabled: true}
 					];
 

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
@@ -63,8 +63,8 @@
 					scope.metadata = {};
 					scope.metadata.selected = 'keep';
 					scope.metadata.data = [
-							{label: 'keep metadata', value: 'keep'},
-							{label: 'extract metadata', value: 'extract', isDisabled: true}
+							{label: 'keep metadata of base ERC', value: 'keep'},
+							{label: 'extract metadata for new ERC', value: 'extract', isDisabled: true}
 					];
 
 					function cancel() {

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js
@@ -60,6 +60,12 @@
 					scope.delDropdown = delDropdown;
 					scope.addDropdown = addDropdown;
 					scope.magnifyFiles = magnifyFiles;
+					scope.metadata = {};
+					scope.metadata.selected = 'keep';
+					scope.metadata.data = [
+							{label: 'keep metadata', value: 'keep'},
+							{label: 'extract metadata', value: 'extract', isDisabled: true}
+					];
 
 					function cancel() {
 					    scope.substitutionRows = [{}];

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.module.js
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.module.js
@@ -1,0 +1,8 @@
+(function(){
+    'use strict';
+
+    angular
+        .module('starter.o2rSubstituteCandidate', [
+            'conf'
+        ]);
+})();

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
@@ -44,4 +44,6 @@
 <div>
   <md-button ng-click="cancel()">cancel</md-button>
   <md-button ng-click="startSubstitutionUI()">start substitution</md-button>
+  <span flex></span>
+  <a href="" ng-click="showSubstitutedERC()" ng-if="finishedSubstitution">Go to ERC</a>
 </div>

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
@@ -1,0 +1,47 @@
+<div id="tableSubstitutionOptions">
+  <table id="tableSubstitution" style="width:100%">
+    <tr style="background-color: white;">
+      <th style="width:45%">base ERC:</th>
+      <th style="width:10%"></th>
+      <th style="width:45%">overlay ERC:</th>
+    </tr>
+    <tr>
+      <th>{{o2rBaseTitle}}</th>
+      <th></th>
+      <th>{{o2rOverlayTitle}}</th>
+    </tr>
+    <div class="substitution-rows">
+      <tr ng-repeat="row in substitutionRows">
+        <td>
+          <md-input-container>
+            <md-select ng-model="fileSelectBase" ng-change="selectSubstitutionFiles(fileSelectBase, baseType, this)" placeholder="Select a basefile">
+              <md-option ng-value="basefile" ng-repeat="basefile in o2rBase">{{ basefile.fileName }}</md-option>
+            </md-select>
+          </md-input-container>
+        </td>
+        <td>
+          <md-button title="del row" class="md-raised" ng-click="delDropdown(this)"><md-icon aria-label md-svg-src="{{icons.remove}}"></md-icon></md-button>
+        </td>
+        <td>
+          <md-input-container>
+            <md-select ng-model="fileSelectOverlay" ng-change="selectSubstitutionFiles(fileSelectOverlay, overlayType, this)" placeholder="Select an overlayfile">
+              <md-option ng-value="overlayfile" ng-repeat="overlayfile in o2rOverlay">{{ overlayfile.fileName }}</md-option>
+            </md-select>
+          </md-input-container>
+        </td>
+      </tr>
+    </div>
+    <tr style="background-color: white;">
+      <td class="add-row-button"></td>
+      <td class="add-row-button">
+        <md-button title="add row" class="md-raised" ng-click="addDropdown()"><md-icon aria-label md-svg-src="{{icons.add}}"></md-icon></md-button>
+      </td>
+      <td class="add-row-button"></td>
+    </tr>
+  </table>
+</div>
+
+<div>
+  <md-button ng-click="cancel()">cancel</md-button>
+  <md-button ng-click="startSubstitutionUI()">start substitution</md-button>
+</div>

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
@@ -45,6 +45,13 @@
 </div>
 
 <div>
+  <md-radio-group ng-model="metadata.selected" class="md-primary">
+    <md-radio-button ng-repeat="data in metadata.data" ng-value="data.value" ng-disabled="data.isDisabled">
+      {{data.label}}
+    </md-radio-button>
+  </md-radio-group>
+</div>
+<div>
   <md-button ng-click="cancel()">cancel</md-button>
   <md-button ng-click="startSubstitutionUI()">start substitution</md-button>
   <span flex></span>

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
@@ -1,14 +1,18 @@
+<!-- <div class="md-dialog-container" id="showCandidateView"> -->
+  <!-- <md-dialog class="substitute_candidate" aria-label="options dialog"> -->
+    <md-dialog-content layout-padding>
+
 <div id="tableSubstitutionOptions">
   <table id="tableSubstitution" style="width:100%">
     <tr style="background-color: white;">
-      <th style="width:45%">base ERC:</th>
+      <th style="width:45%"><h2>base ERC:</h2></th>
       <th style="width:10%"></th>
-      <th style="width:45%">overlay ERC:</th>
+      <th style="width:45%"><h2>overlay ERC:</h2></th>
     </tr>
     <tr>
-      <th>{{o2rBaseTitle}}</th>
+      <th><h3>{{o2rBaseTitle}}</h3></th>
       <th></th>
-      <th>{{o2rOverlayTitle}}</th>
+      <th><h3>{{o2rOverlayTitle}}</h3></th>
     </tr>
     <div class="substitution-rows">
       <tr ng-repeat="row in substitutionRows">
@@ -20,6 +24,7 @@
           </md-input-container>
         </td>
         <td>
+          <md-button title="magnify row" ng-click="magnifyFiles($event, this)"><md-icon aria-label md-svg-src="{{icons.search}}"></md-icon></md-button>
           <md-button title="del row" class="md-raised" ng-click="delDropdown(this)"><md-icon aria-label md-svg-src="{{icons.remove}}"></md-icon></md-button>
         </td>
         <td>
@@ -47,3 +52,7 @@
   <span flex></span>
   <a href="" ng-click="showSubstitutedERC()" ng-if="finishedSubstitution">Go to ERC</a>
 </div>
+
+</md-dialog-content>
+<!-- </md-dialog> -->
+<!-- </div> -->

--- a/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
+++ b/client/app/o2rSubstituteCandidate/o2rSubstituteCandidate.template.html
@@ -1,6 +1,4 @@
-<!-- <div class="md-dialog-container" id="showCandidateView"> -->
-  <!-- <md-dialog class="substitute_candidate" aria-label="options dialog"> -->
-    <md-dialog-content layout-padding>
+<md-dialog-content layout-padding>
 
 <div id="tableSubstitutionOptions">
   <table id="tableSubstitution" style="width:100%">
@@ -54,5 +52,3 @@
 </div>
 
 </md-dialog-content>
-<!-- </md-dialog> -->
-<!-- </div> -->

--- a/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.directive.js
+++ b/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.directive.js
@@ -1,0 +1,75 @@
+(function(){
+    'use strict';
+
+  	/*
+  		Directive for displaying two files for comparison.
+  		This directive uses the o2rDisplayFiles directive to show two files nex to each other for comparison.
+      o2r-overlay-id must be a String.
+  		o2r-base-file, o2r-overlay-file must be a String that contains the path to a file.
+
+  		Example:
+  		<o2r-substitute-magnify o2r-base-file="foo/bar" o2r-overlay-file="foo/bar" o2r-overlay-id)="{{"foo"}}"></o2r-substitute-magnify>
+  	*/
+    angular
+        .module('starter.o2rSubstituteMagnify', [])
+        .directive('o2rSubstituteMagnify', o2rSubstituteMagnify);
+
+    o2rSubstituteMagnify.$inject = ['$stateParams', '$log', '$mdDialog', 'icons'];
+    function o2rSubstituteMagnify($stateParams, $log, $mdDialog, icons){
+        return{
+    			restrict: 'E',
+    			templateUrl: 'app/o2rSubstituteMagnify/o2rSubstituteMagnify.template.html',
+    			scope: {
+    				o2rBaseFile: '@',
+    				o2rOverlayFile: '@',
+            o2rOverlayId: '@'
+    			},
+    			link: link
+    		};
+
+        function link(scope, iElemtn, attrs) {
+            var logger = $log.getInstance('SubstituteCtrl');
+
+            attrs.$observe('o2rBaseFile', function(val_) {
+    				    if(val_ != '') {
+
+                    logger.info('substituteMagnify view');
+                    scope.icons = icons;
+                    scope.magnBase = {};
+                    scope.magnBase.path = 'http://localhost/api/v1/compendium/' + $stateParams.ercid + '/data/' + scope.o2rBaseFile;
+                    scope.magnBase.type = 'text/html';
+                    scope.magnOverlay = {};
+                    scope.magnOverlay.path = 'http://localhost/api/v1/compendium/' + scope.o2rOverlayId + '/data/' + scope.o2rOverlayFile;
+                    scope.magnOverlay.type = 'text/html';
+
+                    scope.cancel = cancel;
+                    scope.hide = hide;
+                    scope.answer = answer;
+                    scope.fileEdit = fileEdit;
+                    scope.saveEdit = saveEdit;
+
+                    /////
+
+                    function fileEdit(filepath) {
+                        console.log(filepath);
+                    };
+
+                    function saveEdit() {
+                    };
+
+                    function cancel (){
+                        $mdDialog.cancel();
+                    };
+
+                    function hide () {
+                        $mdDialog.hide();
+                    };
+
+                    function answer (answer) {
+                        $mdDialog.hide(answer);
+                    };
+                }
+            })
+        }
+    }
+})(window.angular)

--- a/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.directive.js
+++ b/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.directive.js
@@ -33,14 +33,12 @@
             attrs.$observe('o2rBaseFile', function(val_) {
     				    if(val_ != '') {
 
-                    logger.info('substituteMagnify view');
                     scope.icons = icons;
                     scope.magnBase = {};
-                    scope.magnBase.path = 'http://localhost/api/v1/compendium/' + $stateParams.ercid + '/data/' + scope.o2rBaseFile;
-                    scope.magnBase.type = 'text/html';
+                    scope.magnBase.path = '/api/v1/compendium/' + $stateParams.ercid + '/data/' + scope.o2rBaseFile;
                     scope.magnOverlay = {};
-                    scope.magnOverlay.path = 'http://localhost/api/v1/compendium/' + scope.o2rOverlayId + '/data/' + scope.o2rOverlayFile;
-                    scope.magnOverlay.type = 'text/html';
+                    scope.magnOverlay.path = '/api/v1/compendium/' + scope.o2rOverlayId + '/data/' + scope.o2rOverlayFile;
+                    logger.info('substituteMagnify view with files basefile [%s] and overlayfile [%s]', scope.magnBase.path, scope.magnOverlay.path);
 
                     scope.cancel = cancel;
                     scope.hide = hide;
@@ -51,7 +49,7 @@
                     /////
 
                     function fileEdit(filepath) {
-                        console.log(filepath);
+                        logger.info(filepath);
                     };
 
                     function saveEdit() {

--- a/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.module.js
+++ b/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.module.js
@@ -1,0 +1,8 @@
+(function(){
+    'use strict';
+
+    angular
+        .module('starter.o2rSubstituteMagnify', [
+            'conf'
+        ]);
+})();

--- a/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.template.html
+++ b/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.template.html
@@ -10,43 +10,43 @@
       </div>
   </md-toolbar>
 
-  <div class="substitute_magnifierCard" layout="row">
-      <md-card flex="100">
-          <md-card-header>
-            <div layout="column" flex="80">
-                <md-card-header-text>
-                    <span>Base File</span>
-                    <span flex></span>
-                </md-card-header-text>
-            </div>
-            <div layout="column" flex="20">
-                <md-button class="md-icon-button md-raised" ng-click="fileEdit(magnBase)">
-                    <md-icon md-svg-src="{{icons.edit}}"></md-icon>
-                </md-button>
-            </div>
-          </md-card-header>
-          <md-card-content>
-            <o2r-display-files o2r-file="{{magnBase}}"></o2r-display-files>
-          </md-card-content>
-      </md-card>
-      <md-card flex="100">
-          <md-card-header>
-            <div layout="column" flex="80">
-                <md-card-header-text>
-                    <span>Overlay File</span>
-                    <span flex></span>
-                </md-card-header-text>
-            </div>
-            <div layout="column" flex="20">
-                <md-button class="md-icon-button md-raised" ng-click="fileEdit(magnBase)">
-                    <md-icon md-svg-src="{{icons.edit}}"></md-icon>
-                </md-button>
-            </div>
-          </md-card-header>
-          <md-card-content>
-            <o2r-display-files o2r-file="{{magnOverlay}}"></o2r-display-files>
-          </md-card-content>
-      </md-card>
+  <div layout="row" class="substitute_magnifier_div">
+    <md-card flex="50" class="substitute_magnifier">
+        <md-card-header>
+          <div layout="column" flex="80">
+              <md-card-header-text>
+                  <span>Base File</span>
+                  <span flex></span>
+              </md-card-header-text>
+          </div>
+          <div layout="column" flex="20">
+              <md-button class="md-icon-button md-raised" ng-click="fileEdit(magnBase)">
+                  <md-icon md-svg-src="{{icons.edit}}"></md-icon>
+              </md-button>
+          </div>
+        </md-card-header>
+        <md-card-content class="substitute_magnifier_Card">
+          <o2r-display-files o2r-file="{{magnBase}}"></o2r-display-files>
+        </md-card-content>
+    </md-card>
+    <md-card flex="50" class="substitute_magnifier">
+        <md-card-header>
+          <div layout="column" flex="80">
+              <md-card-header-text>
+                  <span>Overlay File</span>
+                  <span flex></span>
+              </md-card-header-text>
+          </div>
+          <div layout="column" flex="20">
+              <md-button class="md-icon-button md-raised" ng-click="fileEdit(magnOverlay)">
+                  <md-icon md-svg-src="{{icons.edit}}"></md-icon>
+              </md-button>
+          </div>
+        </md-card-header>
+        <md-card-content class="substitute_magnifier_Card">
+          <o2r-display-files o2r-file="{{magnOverlay}}"></o2r-display-files>
+        </md-card-content>
+    </md-card>
   </div>
 
   <!-- footer -->

--- a/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.template.html
+++ b/client/app/o2rSubstituteMagnify/o2rSubstituteMagnify.template.html
@@ -1,0 +1,66 @@
+<div id="magnifyFiles" flex="100">
+  <!-- toolbar -->
+  <md-toolbar>
+      <div class="md-toolbar-tools">
+          <h2 class="white-font">compare files</h2>
+          <span flex></span>
+          <md-button class="md-icon-button" ng-click="cancel()">
+              <md-icon class="o2r-white-icon" md-svg-src="{{icons.close}}" arial-label="Close dialog"></md-icon>
+          </md-button>
+      </div>
+  </md-toolbar>
+
+  <div class="substitute_magnifierCard" layout="row">
+      <md-card flex="100">
+          <md-card-header>
+            <div layout="column" flex="80">
+                <md-card-header-text>
+                    <span>Base File</span>
+                    <span flex></span>
+                </md-card-header-text>
+            </div>
+            <div layout="column" flex="20">
+                <md-button class="md-icon-button md-raised" ng-click="fileEdit(magnBase)">
+                    <md-icon md-svg-src="{{icons.edit}}"></md-icon>
+                </md-button>
+            </div>
+          </md-card-header>
+          <md-card-content>
+            <o2r-display-files o2r-file="{{magnBase}}"></o2r-display-files>
+          </md-card-content>
+      </md-card>
+      <md-card flex="100">
+          <md-card-header>
+            <div layout="column" flex="80">
+                <md-card-header-text>
+                    <span>Overlay File</span>
+                    <span flex></span>
+                </md-card-header-text>
+            </div>
+            <div layout="column" flex="20">
+                <md-button class="md-icon-button md-raised" ng-click="fileEdit(magnBase)">
+                    <md-icon md-svg-src="{{icons.edit}}"></md-icon>
+                </md-button>
+            </div>
+          </md-card-header>
+          <md-card-content>
+            <o2r-display-files o2r-file="{{magnOverlay}}"></o2r-display-files>
+          </md-card-content>
+      </md-card>
+  </div>
+
+  <!-- footer -->
+  <md-toolbar class="footer">
+      <div class="md-toolbar-tools white-font">
+          <span flex></span>
+          <md-button class="md-icon-button md-raised" ng-click="cancel()">
+            <md-icon class="o2r-white-icon" md-svg-src="{{icons.backArrow}}" arial-label="Close dialog"></md-icon>
+          </md-button>
+          <md-button class="md-raised" ng-click="saveEdit()">
+            save edit
+          </md-button>
+          <span flex></span>
+      </div>
+  </md-toolbar>
+
+</div>

--- a/client/app/substituteView/substitute.controller.js
+++ b/client/app/substituteView/substitute.controller.js
@@ -53,7 +53,7 @@
                     parent: angular.element(document.body),
                     scope: $scope,
                     preserveScope: true,
-                    multiple: false,
+                    multiple: true,
                     targetEvent: event,
                     clickOutsideToClose: false
                 });

--- a/client/app/substituteView/substitute.controller.js
+++ b/client/app/substituteView/substitute.controller.js
@@ -9,148 +9,29 @@
     function SubstituteController($scope, $log, $stateParams, $q, $mdDialog, httpRequests, substituteInfoService, metadataSimComp, icons, erc){
         var logger = $log.getInstance('SubstituteCtrl');
         var vm = this;
-
         logger.info("Substituter is working in compendium: "+ $stateParams.ercid);
 
         vm.icons = icons;
         vm.similarPubs = getMetadataSimComp();
         vm.publication = erc;
         $scope.substituteOptions = getSubstituteOptions;
-        $scope.baseType = "base";
-        $scope.overlayType = "overlay";
-        $scope.substitutionRows = [{}];
-        $scope.baseCandidates = [];
-        $scope.overlayCandidates = [];
-        $scope.selectedSubstitutionFiles = [];
-        $scope.delDropdown = delDropdown;
-        $scope.addDropdown = addDropdown;
 
         // set width of div with ERC title in selection list
         var substERCtitleWidth = $("#substitutionErcSelectionViewTitle").context.body.clientWidth;
         vm.divWidth = parseInt((substERCtitleWidth/100 + 10), 10);
-
-        //////////////////
 
         $scope.$on('loadedSimilarComps', function(event, data){
             // similarPubs will be set to comp_meta from metadata factory
             vm.similarPubs = data;
         });
 
-        $scope.cancel = function() {
-            $scope.substitutionRows = [{}];
-            $mdDialog.cancel();
-        };
-
-        // TODO: start substitution UI
-        $scope.startSubstitutionUI = function() {
-            logger.info("initiateSubstitution");
-            logger.debug("initiateSubstitution");
-
-            if (!Array.isArray($scope.substitutionRows) || $scope.substitutionRows == undefined || $scope.substitutionRows.length == 0 || !checkForFiles($scope.substitutionRows)) {
-                logger.info("no substitution files choosen");
-                window.alert("please choose files");
-            } else {
-                $mdDialog.hide();
-                logger.info("init substitution");
-                // start substitution
-
-                let substitutionMetadata = {};
-                let arrayOfSubstitutionObjects = [];
-
-
-                console.log($scope.substitutionRows);
-                console.log(vm.base);
-                console.log(vm.overlay);
-
-                substitutionMetadata.base = vm.base.id;
-                substitutionMetadata.overlay = vm.overlay.id;
-                substitutionMetadata.substitutionFiles = [];
-
-                for (let i=0; i<$scope.substitutionRows.length; i++) {
-                  let object_ = {};
-                  object_.base = $scope.substitutionRows[i].basefile.filePath;
-                  object_.overlay = $scope.substitutionRows[i].overlayfile.filePath;
-                  substitutionMetadata.substitutionFiles.push(object_);
-                }
-
-                console.log(substitutionMetadata);
-
-                httpRequests.substitute(substitutionMetadata)
-                  .then(function(res){
-                      console.log(res);
-                  })
-                  .catch(function(err){
-                    console.log(err);
-                  });
-            }
-        };
-
-        // on change of dropdown list
-        $scope.selectSubstitutionFiles = function(file, type, row) {
-            let i = row.$index;
-            let baseCandidatesLength = $scope.baseCandidates.length;
-            let overlayCandidatesLength = $scope.overlayCandidates.length;
-            let oldBaseCandidatePosition; // = $scope.substitutionRows[i].basefile.$$mdSelectId;
-            let newBaseCandidatePosition;
-            let oldOverlayCandidatePosition; // = $scope.substitutionRows[i].overlayfile.$$mdSelectId;
-            let newOverlayCandidatePosition;
-
-            // change "selected" to TRUE of new file
-            if (type == "base") {
-                newBaseCandidatePosition = file.$$mdSelectId;
-                // $$mdSelectId will add up all files that have been inside of md-select (when cancelling md-dialog and open again)
-                while (newBaseCandidatePosition > (baseCandidatesLength + overlayCandidatesLength)) {
-                    newBaseCandidatePosition = newBaseCandidatePosition - (baseCandidatesLength + overlayCandidatesLength);
-                }
-                // change "selected" to FALSE of exchanged file
-                if ($scope.substitutionRows[i].basefile != undefined) {
-                    oldBaseCandidatePosition = $scope.substitutionRows[i].basefile.$$mdSelectId;
-                    $scope.baseCandidates[oldBaseCandidatePosition-1].selected = false;
-                }
-                $scope.substitutionRows[i].basefile = file;
-                $scope.baseCandidates[newBaseCandidatePosition-1].selected = true;
-            }
-            if (type == "overlay") {
-                newOverlayCandidatePosition = file.$$mdSelectId;
-                // $$mdSelectId will add up all files that have been inside of md-select (when cancelling md-dialog and open again)
-                while (newOverlayCandidatePosition > (baseCandidatesLength + overlayCandidatesLength)) {
-                    newOverlayCandidatePosition = newOverlayCandidatePosition - (baseCandidatesLength + overlayCandidatesLength);
-                }
-                // change "selected" to FALSE of exchanged file
-                if ($scope.substitutionRows[i].overlayfile != undefined) {
-                    oldOverlayCandidatePosition = $scope.substitutionRows[i].overlayfile.$$mdSelectId;
-                    $scope.overlayCandidates[oldOverlayCandidatePosition-1-baseCandidatesLength].selected = false;
-                }
-                $scope.substitutionRows[i].overlayfile = file;
-                $scope.overlayCandidates[newOverlayCandidatePosition-1-baseCandidatesLength].selected = true;
-            }
-        };
-
         //////////////////
-
-        function substitutionCandidate(basefile, overlayfile) {
-            this.basefile = basefile;
-            this.overlayfile = overlayfile;
-        };
 
         function getMetadataSimComp(){
             if(metadataSimComp.status == 404){
                 return false;
             }
             return substituteInfoService; // metadataSimComp.callMetadata_simComp;
-        };
-
-        function checkForFiles(array) {
-          // true = contains files , false = no files
-            if (Array.isArray(array)) {
-                for (let i=0; i<array.length; i++) {
-                    if (typeof(array[i].basefile) != "object" || typeof(array[i].overlayfile) != "object") {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            return false;
         };
 
         // function to provide files for substitution as candidates
@@ -164,16 +45,8 @@
                 logger.debug("no inputfiles for substitution");
                 window.alert("no substitution possible");
             } else {
-                $scope.filePairs = [];
-                $scope.baseCandidates = [];
-                $scope.overlayCandidates = [];
-
-                // put filenames relevant for substitution in array
                 vm.basefiles = getFileCandidates(vm.base);
                 vm.overlayfiles = getFileCandidates(vm.overlay);
-
-                $scope.baseCandidates = getFileCandidates(vm.base);
-                $scope.overlayCandidates = getFileCandidates(vm.overlay);
 
                 $mdDialog.show({
                     contentElement: '#showCandidateView',
@@ -206,26 +79,10 @@
                     let char_2 = filePath.lastIndexOf("/");
                     candidateObject.fileName = filePath.substring(char_2+1);
                 }
+                candidateObject.uId = i+1;
                 candidatesArray.push(candidateObject);
             }
             return candidatesArray;
-        };
-
-        function delDropdown(row) {
-            var i = row.$index;
-            if ($scope.substitutionRows.length <= 1) {
-                // TODO: button in red to warn
-            } else {
-              $scope.substitutionRows.splice(i, 1);
-            }
-        };
-
-        function addDropdown() {
-          if ($scope.substitutionRows.length <= $scope.baseCandidates.length && $scope.substitutionRows.length <= $scope.overlayCandidates) {
-              $scope.substitutionRows.push({});
-          } else {
-              // TODO: button in red to warn
-          }
         };
 
     }

--- a/client/app/substituteView/substitute.html
+++ b/client/app/substituteView/substitute.html
@@ -17,7 +17,7 @@
                 <p flex>{{pub.metadata.raw.description}}</p>
               </div>
               <div flex="30">
-                <md-button title="substitution options" class="md-raised" ng-click="substituteOptions($event, pub)"><md-icon aria-label md-svg-src="{{vm.icons.substitution_options}}"></md-icon></md-button>
+                <md-button title="substitution options" class="md-raised" ng-click="substituteOptions(event, pub)"><md-icon aria-label md-svg-src="{{vm.icons.substitution_options}}"></md-icon></md-button>
               </div>
             </div>
           </div>
@@ -37,62 +37,14 @@
     </md-card-content>
   </md-card>
 
-
-
 <div style="visibility: hidden">
   <div class="md-dialog-container" id="showCandidateView">
     <md-dialog aria-label="options dialog">
       <md-dialog-content layout-padding>
 
-      <div id="tableSubstitutionOptions">
-        <table id="tableSubstitution" style="width:100%">
-          <tr style="background-color: white;">
-            <th style="width:45%">base ERC:</th>
-            <th style="width:10%"></th>
-            <th style="width:45%">overlay ERC:</th>
-          </tr>
-          <tr>
-            <th>{{vm.base.metadata.o2r.title}}</th>
-            <th></th>
-            <th>{{vm.overlay.metadata.o2r.title}}</th>
-          </tr>
-          <div class="substitution-rows">
-            <tr ng-repeat="row in substitutionRows">
-              <td>
-                <md-input-container>
-                  <md-select ng-model="fileSelectBase" ng-change="selectSubstitutionFiles(fileSelectBase, baseType, this)" placeholder="Select a basefile">
-                    <md-option ng-value="basefile" ng-repeat="basefile in baseCandidates">{{ basefile.fileName }}</md-option>
-                  </md-select>
-                </md-input-container>
-              </td>
-              <td>
-                <md-button title="del row" class="md-raised" ng-click="delDropdown(this)"><md-icon aria-label md-svg-src="{{vm.icons.remove}}"></md-icon></md-button>
-              </td>
-              <td>
-                <md-input-container>
-                  <md-select ng-model="fileSelectOverlay" ng-change="selectSubstitutionFiles(fileSelectOverlay, overlayType, this)" placeholder="Select an overlayfile">
-                    <md-option ng-value="overlayfile" ng-repeat="overlayfile in overlayCandidates">{{ overlayfile.fileName }}</md-option>
-                  </md-select>
-                </md-input-container>
-              </td>
-            </tr>
-          </div>
-          <tr style="background-color: white;">
-            <td class="add-row-button"></td>
-            <td class="add-row-button">
-              <md-button title="add row" class="md-raised" ng-click="addDropdown()"><md-icon aria-label md-svg-src="{{vm.icons.add}}"></md-icon></md-button>
-            </td>
-            <td class="add-row-button"></td>
-          </tr>
-        </table>
-      </div>
+        <o2r-substitute-candidate o2r-base="vm.basefiles" o2r-overlay="vm.overlayfiles" o2r-base-title="{{vm.base.metadata.o2r.title}}" o2r-overlay-title="{{vm.overlay.metadata.o2r.title}}" o2r-base-id="{{vm.base.id}}" o2r-overlay-id="{{vm.overlay.id}}"></o2r-substitute-candidate>
 
-      <div>
-          <md-button ng-click="cancel()">cancel</md-button>
-          <md-button ng-click="startSubstitutionUI()">start substitution</md-button>
-      </div>
-
-    </md-dialog-content>
+      </md-dialog-content>
     </md-dialog>
   </div>
 </div>

--- a/client/app/substituteView/substitute.html
+++ b/client/app/substituteView/substitute.html
@@ -17,7 +17,7 @@
                 <p flex>{{pub.metadata.raw.description}}</p>
               </div>
               <div flex="30">
-                <md-button title="substitution options" class="md-raised" ng-click="substituteOptions(event, pub)"><md-icon aria-label md-svg-src="{{vm.icons.substitution_options}}"></md-icon></md-button>
+                <md-button title="substitution options" class="md-raised" ng-click="substituteOptions($event, pub)"><md-icon aria-label md-svg-src="{{vm.icons.substitution_options}}"></md-icon></md-button>
               </div>
             </div>
           </div>
@@ -39,12 +39,12 @@
 
 <div style="visibility: hidden">
   <div class="md-dialog-container" id="showCandidateView">
-    <md-dialog aria-label="options dialog">
-      <md-dialog-content layout-padding>
+    <md-dialog class="substitute_candidate" aria-label="options dialog">
+      <!-- <md-dialog-content layout-padding> -->
 
         <o2r-substitute-candidate o2r-base="vm.basefiles" o2r-overlay="vm.overlayfiles" o2r-base-title="{{vm.base.metadata.o2r.title}}" o2r-overlay-title="{{vm.overlay.metadata.o2r.title}}" o2r-base-id="{{vm.base.id}}" o2r-overlay-id="{{vm.overlay.id}}"></o2r-substitute-candidate>
 
-      </md-dialog-content>
+      <!-- </md-dialog-content> -->
     </md-dialog>
   </div>
 </div>

--- a/client/css/o2r.css
+++ b/client/css/o2r.css
@@ -623,11 +623,40 @@ td.add-row-button {
 	min-width: 80%;
 }
 
-.substitute_magnifier{
+#magnifyFiles{
 	max-width: 100%;
 	width: 100%;
+	height: 100%;
 }
 
+.substitute_magnifier{
+	width: 100%;
+	height: 100% /* 80vh;*/
+}
+
+.substitute_magnifier > md-card-header{
+	min-height: 2vh;
+}
+
+.substitute_magnifier > md-card-content{
+	overflow-y: auto;
+}
+
+o2r-substitute-magnify{
+	height: 100%;
+}
+
+.substitute_magnifier_div{
+	height: calc(100% - 64px - 64px);	/* dialog height - toolbar - footer */
+}
+
+.substitute_magnifier_Card{
+	height: 100%;
+}
+
+.substitute_magnifier_Card > o2r-display-files > iframe.display-files-html{
+	height: 100% !important;
+}
 /***********************
 	End Substitution
 /***********************

--- a/client/css/o2r.css
+++ b/client/css/o2r.css
@@ -618,6 +618,16 @@ td.add-row-button {
 	border-bottom: white;
 }
 
+.substitute_candidate{
+	max-width: 100%;
+	min-width: 80%;
+}
+
+.substitute_magnifier{
+	max-width: 100%;
+	width: 100%;
+}
+
 /***********************
 	End Substitution
 /***********************

--- a/client/img/ic_arrow_back_24px.svg
+++ b/client/img/ic_arrow_back_24px.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+</svg>

--- a/client/img/ic_arrow_back_48px.svg
+++ b/client/img/ic_arrow_back_48px.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="48" viewBox="0 0 24 24" width="48" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+</svg>

--- a/client/index.html
+++ b/client/index.html
@@ -83,6 +83,7 @@
 <script src="app/o2rInspect/o2rInspect.module.js"></script>
 <script src="app/o2rErcDownload/o2rErcDownload.module.js"></script>
 <script src="app/o2rMetadataView/o2rMetadataView.module.js"></script>
+<script src="app/o2rSubstituteCandidate/o2rSubstituteCandidate.module.js"></script>
 
 <!-- Services -->
 <script src="app/o2rHttp/httpRequests.js"></script>
@@ -129,6 +130,7 @@
 <script src="app/o2rCompare/o2rCompare.directive.js"></script>
 <script src="app/o2rInspect/o2rInspect.directive.js"></script>
 <script src="app/o2rErcDownload/o2rErcDownload.directive.js"></script>
+<script src="app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js"></script>
 
 <!-- Filters -->
 <script src="app/services/upperCase.filter.js"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -84,6 +84,7 @@
 <script src="app/o2rErcDownload/o2rErcDownload.module.js"></script>
 <script src="app/o2rMetadataView/o2rMetadataView.module.js"></script>
 <script src="app/o2rSubstituteCandidate/o2rSubstituteCandidate.module.js"></script>
+<script src="app/o2rSubstituteMagnify/o2rSubstituteMagnify.module.js"></script>
 
 <!-- Services -->
 <script src="app/o2rHttp/httpRequests.js"></script>
@@ -131,6 +132,7 @@
 <script src="app/o2rInspect/o2rInspect.directive.js"></script>
 <script src="app/o2rErcDownload/o2rErcDownload.directive.js"></script>
 <script src="app/o2rSubstituteCandidate/o2rSubstituteCandidate.directive.js"></script>
+<script src="app/o2rSubstituteMagnify/o2rSubstituteMagnify.directive.js"></script>
 
 <!-- Filters -->
 <script src="app/services/upperCase.filter.js"></script>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,17 +155,6 @@ services:
       - DEBUG=*
       #substituter,substituter:*
 
-  opencpu:
-    image: opencpu/rstudio
-    restart: unless-stopped
-    # depends_on:
-    #   - configmongodb
-    volumes:
-      - o2rstorage:/tmp/o2r
-    environment:
-      - OPENCPU_PORT=8004
-      - DEBUG=*
-
   platform:
     image: nginx:latest
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       SHIPPER_BASE_PATH: "/tmp/o2r"
 
   substituter:
-    image: o2rproject/o2r-substituter:0.3.0
+    image: o2rproject/o2r-substituter:0.3.1
     restart: unless-stopped
     depends_on:
       - configmongodb
@@ -152,7 +152,19 @@ services:
     environment:
       - "SUBSTITUTER_MONGODB=mongodb://mongodb"
       - SUBSTITUTER_PORT=8090
-      - DEBUG=substituter,substituter:*
+      - DEBUG=*
+      #substituter,substituter:*
+
+  opencpu:
+    image: opencpu/rstudio
+    restart: unless-stopped
+    # depends_on:
+    #   - configmongodb
+    volumes:
+      - o2rstorage:/tmp/o2r
+    environment:
+      - OPENCPU_PORT=8004
+      - DEBUG=*
 
   platform:
     image: nginx:latest


### PR DESCRIPTION
update candidate view
- dropdown for substitution files to be selected
- start substitution and "go to ERC"-link, if substitution was successfull

update file magnifier
- show filecontent of files that will be substituted to see i.e. differences

update erc view
- show if an ERC is a substiuttion
- possibility to go to the base and overlay ERC by link