### PR TITLE
Update microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The compose configuration also makes a simple test page for WebSockets available
 
 ## Platform Version
 
-0.9.5
+0.9.6
 
 ## License
 

--- a/bower.json
+++ b/bower.json
@@ -53,8 +53,7 @@
     "angular-ui-router": "^0.3.2"
   },
   "resolutions": {
-    "angular": "1.6.6",
-    "leaflet": "1.0.3",
-    "ui-leaflet": "1.0.3"
+    "angular": ">1.2.0",
+    "ui-leaflet": "^2.0.0"
   }
 }

--- a/client/app/ercView/erc.controller.js
+++ b/client/app/ercView/erc.controller.js
@@ -39,12 +39,14 @@
         Replace this code with the right path to code files as soon as metadata contains this information
         */
         vm.inspect.code = [];
+        /*
         vm.inspect.code.push({
             path: vm.publication.metadata.o2r.file.filepath,
             type: vm.publication.metadata.o2r.file.mimetype,
             name: vm.publication.metadata.o2r.file.filename
         });
-
+        */
+        
         vm.loggedIn = login.isLoggedIn();
         vm.shipped = false;
         vm.publish = true;

--- a/dev/nginx-microservices.conf
+++ b/dev/nginx-microservices.conf
@@ -91,12 +91,7 @@ http {
     location /api/v1/search {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://172.17.0.1:9200/o2r/compendia/_search;
-
-      # for requests other than GET you must enter the container
-      limit_except GET {
-        deny all;
-      }
+      proxy_pass http://172.17.0.1:8084;
     }
 
     location /api/v1/shipment {

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -90,12 +90,7 @@ http {
     location /api/v1/search {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://elasticsearch:9200/o2r/compendia/_search;
-
-      # for requests other than GET you must enter the container
-      limit_except GET {
-        deny all;
-      }
+      proxy_pass http://finder:8084;
     }
 
     location /api/v1/shipment {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@
 #
 #
 ---
-version: '3'
+version: '2' # version 3 is for stack deployments, see https://github.com/docker/compose/issues/4513
 
 volumes:
   o2rstorage: {}
@@ -41,13 +41,35 @@ services:
       - "1234:1234"
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.4
     environment:
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - cluster.name=o2rplatform-es-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "xpack.security.enabled=false"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
+    #ports:
+    #  - 9200:9200
+  elasticsearch2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.4
+    environment:
+      - cluster.name=o2rplatform-es-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "discovery.zen.ping.unicast.hosts=elasticsearch"
+      - "xpack.security.enabled=false"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
 
   muncher:
-    image: o2rproject/o2r-muncher:0.12.3
+    image: o2rproject/o2r-muncher:0.13.0
     restart: unless-stopped
     depends_on:
       - configmongodb
@@ -58,9 +80,10 @@ services:
       - "MUNCHER_MONGODB=mongodb://mongodb"
       - MUNCHER_PORT=8080
       - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+      #- "MUNCHER_META_TOOL_CONTAINER=o2rproject/o2r-meta:dev" 
 
   loader:
-    image: o2rproject/o2r-loader:0.7.3
+    image: o2rproject/o2r-loader:0.8.0
     restart: unless-stopped
     depends_on:
       - configmongodb
@@ -71,6 +94,7 @@ services:
       - "LOADER_MONGODB=mongodb://mongodb"
       - LOADER_PORT=8088
       - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+      #- "LOADER_META_TOOL_CONTAINER=o2rproject/o2r-meta:dev" 
 
   informer:
     image: o2rproject/o2r-informer:0.3.0
@@ -95,11 +119,13 @@ services:
       - OAUTH_URL_CALLBACK=${OAUTH_URL_CALLBACK}
       - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
       - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
+      - OAUTH_URL_AUTHORIZATION=${OAUTH_URL_AUTHORIZATION}
+      - OAUTH_URL_TOKEN=${OAUTH_URL_TOKEN}
       - SLACK_VERIFICATION_TOKEN=${SLACK_VERIFICATION_TOKEN}
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
 
   finder:
-    image: o2rproject/o2r-finder:0.3.2
+    image: finder #o2rproject/o2r-finder:0.5.0
     restart: unless-stopped
     depends_on:
       - mongodb
@@ -108,7 +134,7 @@ services:
     volumes:
       - o2rstorage:/tmp/o2r
     environment:
-      - "FINDER_MONGODB_USER_DATABASE=mongodb://mongodb/muncher"
+      - "FINDER_MONGODB=mongodb://mongodb"
       - FINDER_PORT=8084
       - DEBUG=finder,finder:*
       - ELASTIC_SEARCH_URL=elasticsearch:9200
@@ -117,7 +143,7 @@ services:
       - BATCH_COUNT=20
 
   transporter:
-    image: o2rproject/o2r-transporter:0.4.0
+    image: o2rproject/o2r-transporter:0.4.1
     restart: unless-stopped
     depends_on:
       - configmongodb
@@ -130,7 +156,7 @@ services:
       - DEBUG=transporter,transporter:*
 
   shipper:
-    image: o2rproject/o2r-shipper:f90fb75
+    image: o2rproject/o2r-shipper:c4b2d27
     restart: unless-stopped
     depends_on:
       - configmongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     mem_limit: 1g
 
   muncher:
-    image: o2rproject/o2r-muncher:0.13.0
+    image: o2rproject/o2r-muncher:0.13.1
     restart: unless-stopped
     depends_on:
       - configmongodb
@@ -79,11 +79,12 @@ services:
     environment:
       - "MUNCHER_MONGODB=mongodb://mongodb"
       - MUNCHER_PORT=8080
+      - MUNCHER_VOLUME=o2rplatform_o2rstorage
       - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
       #- "MUNCHER_META_TOOL_CONTAINER=o2rproject/o2r-meta:dev" 
 
   loader:
-    image: o2rproject/o2r-loader:0.8.0
+    image: o2rproject/o2r-loader:0.8.1
     restart: unless-stopped
     depends_on:
       - configmongodb
@@ -94,8 +95,9 @@ services:
       - "LOADER_MONGODB=mongodb://mongodb"
       - LOADER_PORT=8088
       - DEBUG=*,-mquery,-express:*,-express-session,-body-parser:*
+      - LOADER_VOLUME=o2rplatform_o2rstorage
       #- "LOADER_META_TOOL_CONTAINER=o2rproject/o2r-meta:dev" 
-
+      
   informer:
     image: o2rproject/o2r-informer:0.3.0
     restart: unless-stopped
@@ -125,7 +127,7 @@ services:
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
 
   finder:
-    image: finder #o2rproject/o2r-finder:0.5.0
+    image: o2rproject/o2r-finder:0.5.1
     restart: unless-stopped
     depends_on:
       - mongodb


### PR DESCRIPTION
**Important changes**

- step details are deactivated by default, see http://o2r.info/o2r-web-api/job/#url-parameters-for-single-job-view
- metadata are now properly brokered and extracted using latest meta tools (development version for meta easily configurable, see README)
- includes updated finder for improved search features, see http://o2r.info/o2r-web-api/search/
- responses are now _empty_ when there is no compendium/job instead of "no X found"
- job include new steps: generate_manifest, generate_configuration, check
- shipper now provides download of complete ERC ("ship to download"), see 
- Elasticsearch now runs in a "mini cluster" of two containers